### PR TITLE
Add support for fluid ads on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -111,5 +111,4 @@ afterEvaluate { project ->
         archives androidSourcesJar
         archives androidJavadocJar
     }
-
 }

--- a/android/src/main/java/com/matejdr/admanager/BannerAdView.java
+++ b/android/src/main/java/com/matejdr/admanager/BannerAdView.java
@@ -62,13 +62,6 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
 
         this.adView = new AdManagerAdView(currentActivityContext);
 
-        if (isFluid()) {
-            AdManagerAdView.LayoutParams layoutParams = new AdManagerAdView.LayoutParams(
-                    ReactViewGroup.LayoutParams.MATCH_PARENT,
-                    ReactViewGroup.LayoutParams.MATCH_PARENT);
-            this.adView.setLayoutParams(layoutParams);
-        }
-
         this.adView.setAppEventListener(this);
         this.adView.setAdListener(new AdListener() {
             @Override
@@ -79,8 +72,22 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
                 if (!isFluid()) {
                     int left = adView.getLeft();
                     int top = adView.getTop();
+
+                    View parent = (View) adView.getParent();
+
+                    if (parent != null) {
+                        int parentWidth = parent.getWidth();
+
+                        left = (parentWidth - width) / 2;
+                    }
+
                     adView.measure(width, height);
                     adView.layout(left, top, left + width, top + height);
+                } else {
+                    AdManagerAdView.LayoutParams layoutParams = new AdManagerAdView.LayoutParams(
+                        ReactViewGroup.LayoutParams.MATCH_PARENT,
+                        ReactViewGroup.LayoutParams.MATCH_PARENT);
+                    adView.setLayoutParams(layoutParams);
                 }
 
                 updateLayout();
@@ -134,11 +141,7 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
 
         });
 
-        updateLayout();
-
         this.addView(this.adView);
-
-        updateLayout();
     }
 
     private class MeasureAndLayoutRunnable implements Runnable {
@@ -149,11 +152,19 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
     }
 
     private boolean isFluid() {
-        if (this.adSize == null) {
+        if (this.adView == null) {
             return false;
         }
 
-        return this.adSize.equals(AdSize.FLUID);
+        AdSize adSize = this.adView.getAdSize();
+
+        if (adSize == null) {
+            return false;
+        }
+
+        boolean isFluid = adSize.isFluid();
+
+        return isFluid;
     }
 
     @Override

--- a/android/src/main/java/com/matejdr/admanager/BannerAdView.java
+++ b/android/src/main/java/com/matejdr/admanager/BannerAdView.java
@@ -225,6 +225,8 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
             cachedWidth = width;
             cachedHeight = height;
 
+            // In case of fluid ads, every GAD view and their subviews must be laid out by hand,
+            // otherwise the web view won't align to the container bounds.
             measureAndLayout(adView, width, height);
 
             ViewGroup child = (ViewGroup) adView.getChildAt(0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freddixx/react-native-ad-manager",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-native-ad-manager",
-  "version": "1.3.7",
+  "name": "@freddixx/react-native-ad-manager",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freddixx/react-native-ad-manager",
   "title": "React Native Ad Manager",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A react-native component for Google Ad Manager banners, interstitials and native ads.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freddixx/react-native-ad-manager",
   "title": "React Native Ad Manager",
-  "version": "1.3.9",
+  "version": "1.4.0",
   "description": "A react-native component for Google Ad Manager banners, interstitials and native ads.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Despite upstream semi-official support for fluid ads, they don't work well with dynamic heights on Android. iOS works fine. This PR aligns and lays out all the internal views to match parent sizes. The caller/host is responsible to set proper dimensions on the ad container, for example using the custom events to communicate size changes from the ad.

The custom behavior is only enabled for fluid ads, others stay as they were. There is some caching and dummy try/catch to guard against unknowns. The layout update is called in quite a few places, just to make sure the ad layout stays in sync.

All this was made by trial-and-error as there are no official APIs to react to ad content size changes on Android (there is an API but only for iOS 🤦‍♂️). We can treat it as a hack.
