### PR TITLE
Use adSize for fluid detection

### DIFF
--- a/android/src/main/java/com/matejdr/admanager/BannerAdView.java
+++ b/android/src/main/java/com/matejdr/admanager/BannerAdView.java
@@ -66,8 +66,10 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
         this.adView.setAdListener(new AdListener() {
             @Override
             public void onAdLoaded() {
-                int width = adView.getAdSize().getWidthInPixels(getContext());
-                int height = adView.getAdSize().getHeightInPixels(getContext());
+                AdSize adSize = adView.getAdSize();
+
+                int width = adSize.getWidthInPixels(getContext());
+                int height = adSize.getHeightInPixels(getContext());
 
                 if (!isFluid()) {
                     int left = adView.getLeft();
@@ -152,6 +154,10 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
     }
 
     private boolean isFluid() {
+        if (this.adSize != null && this.adSize.equals(AdSize.FLUID)) {
+            return true;
+        }
+
         if (this.adView == null) {
             return false;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freddixx/react-native-ad-manager",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freddixx/react-native-ad-manager",
   "title": "React Native Ad Manager",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "A react-native component for Google Ad Manager banners, interstitials and native ads.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The resulting `adSize` is still a banner on Android. Now the `adSize` prop is used as a source of truth for this.