### PR TITLE
Detect native fluid ads by app events on Android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freddixx/react-native-ad-manager",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freddixx/react-native-ad-manager",
   "title": "React Native Ad Manager",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "A react-native component for Google Ad Manager banners, interstitials and native ads.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Even for native/fluid ads, the Android ads library reports them as plain banner ads. This is preventing the layout of the ad properly as the 320_50_mb is a valid banner size. With this PR, the fluid/native ad is detected anytime the ad sends any custom ad event.

The issue is deep within the Google Ads library, affecting others as well, for example, https://github.com/sbugert/react-native-admob/issues/206.

<img width="697" alt="Zrzut ekranu 2022-03-2 o 19 33 00" src="https://user-images.githubusercontent.com/30114244/156779041-2cfc34f5-8579-44ea-9848-e958431188c7.png">
