### PR TITLE
Try/catch everything to make ads fail-safe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freddixx/react-native-ad-manager",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freddixx/react-native-ad-manager",
   "title": "React Native Ad Manager",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "A react-native component for Google Ad Manager banners, interstitials and native ads.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We started to observe some random crashes within `createAdView` / `new AdManagerAdView` without any real cause. To avoid such issues, the code is now made fail-safe, dispatching an error event in such cases if possible.

<img width="617" alt="Zrzut ekranu 2022-04-12 o 07 49 09" src="https://user-images.githubusercontent.com/30114244/162889654-ec01f962-77f8-4549-ae70-f6526d92a19f.png">
